### PR TITLE
Make config file option work for non-LDAP case

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,11 @@ class saslauthd::config {
     default => absent
   }
 
+  $config_file_option = $saslauthd::mechanisms ? {
+    'ldap'  => "-O $saslauthd::config_file ",
+    default => ""
+  }
+
   file {
     'saslauthd.conf':
       ensure  => $ensure,

--- a/templates/Debian/default-saslauthd.erb
+++ b/templates/Debian/default-saslauthd.erb
@@ -52,4 +52,4 @@ THREADS=<%= @threads %>
 # information about these options.
 #
 # Example for postfix users: "-c -m /var/spool/postfix/var/run/saslauthd"
-OPTIONS="-O <%= @config_file %> -m <%= @socket_dir %> <%= @options %> <%= @options %>"
+OPTIONS="<%= @config_file_option %>-m <%= @socket_dir %> <%= @options %>"

--- a/templates/RedHat/default-saslauthd.erb
+++ b/templates/RedHat/default-saslauthd.erb
@@ -8,4 +8,4 @@ MECH="<%= @mechanisms %>"
 
 # Additional flags to pass to saslauthd on the command line.  See saslauthd(8)
 # for the list of accepted flags.
-FLAGS="-O <%= @config_file %> <%= @options %>"
+FLAGS="<%= @config_file_option %><%= @options %>"


### PR DESCRIPTION
Only add -O to saslauthd command line if saslauthd.conf is actually created.
saslauthd will silently croak (at least on Debian jessie) otherwise.

Also remove double mention of @options from saslauthd command line on Debian.
